### PR TITLE
Use `calc_element()` to get ticks length

### DIFF
--- a/R/axis_combmatrix.R
+++ b/R/axis_combmatrix.R
@@ -217,12 +217,13 @@ render_comb_axis <- function(self, panel_params, axis=c("primary", "secondary"),
   )
 
   nticks <- length(at)
+  ticks_length <- calc_element(paste0("axis.ticks.length.x.", position), theme)
   ticks <- switch(position,
      top = element_render(theme, "axis.ticks.x.top", x = rep(at, each = 2),
-                          y = rep(unit.c(zero, theme$axis.ticks.length), nticks),
+                          y = rep(unit.c(zero, ticks_length), nticks),
                           id.lengths = rep(2, nticks)),
      bottom = element_render(theme, "axis.ticks.x.bottom", x = rep(at, each = 2),
-                             y = rep(unit.c(one - theme$axis.ticks.length, one), nticks),
+                             y = rep(unit.c(one - ticks_length, one), nticks),
                              id.lengths = rep(2, nticks))
   )
 
@@ -272,11 +273,11 @@ render_comb_axis <- function(self, panel_params, axis=c("primary", "secondary"),
 
   if(position == "bottom"){
     gt <- gtable_col("axis", grobs = list(ticks, axis_repl),
-                     width = one, heights = unit.c(theme$axis.ticks.length, label_height))
+                     width = one, heights = unit.c(ticks_length, label_height))
     justvp <- viewport(y = 1, just = "top", height = gtable_height(gt))
   }else{
     gt <- gtable_col("axis", grobs = list(axis_repl,ticks),
-                     width = one, heights = unit.c(label_height, theme$axis.ticks.length))
+                     width = one, heights = unit.c(label_height, ticks_length))
     justvp <-  viewport(y = 0, just = "bottom",    height = gtable_height(gt))
   }
 


### PR DESCRIPTION
Hi Constantin,

Good to see you yesterday!
Unfortunately today, I'm the bearer of bad news that I found a revdep error in ggplot2 that involved [{ggupset}](https://github.com/tidyverse/ggplot2/blob/revdep-2025-22-01/revdep/problems.md#ggupset), tracked in https://github.com/tidyverse/ggplot2/pull/6287.
The good news is that this PR should fix it!
We've not set ourselves a deadline yet on when we want to release the next ggplot2 version, but I imagine it is a few months away.

Cheers!